### PR TITLE
Missing build requirements.txt

### DIFF
--- a/build_python_package.sh
+++ b/build_python_package.sh
@@ -47,7 +47,7 @@ fi
 # shellcheck disable=SC1091
 source "$environment_name/bin/activate"
 
-pip install -U -r build/requirements.txt --no-warn-script-location
+pip install -U -r build_python_rq/requirements.txt --no-warn-script-location
 
 : "${PYTHONPATH:=}"
 PYTHONPATH="${PWD}/version_git/src/version_git:${PYTHONPATH}"

--- a/build_python_rq/requirements.txt
+++ b/build_python_rq/requirements.txt
@@ -1,0 +1,8 @@
+# Needed for package building
+build
+pip
+setuptools
+Sphinx
+towncrier
+virtualenv
+wheel


### PR DESCRIPTION
I missed that build was one of ignored directories from the previous design of D-Rats.  As build is commonly used as temporary build directory, I renamed the missing directory.

build_python_rq/requirements.txt: New file
build_python_package.sh fixed to reference the new file.